### PR TITLE
fastify 5: fix deprecation warning

### DIFF
--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -31,7 +31,7 @@ const plugin = require('../');
       reply.send({ query })
     })
 
-    fastify.listen(0, async (err) => {
+    fastify.listen({ port: 0, host: 'localhost' }, async (err) => {
       fastify.server.unref()
       if (err) t.threw(err)
 
@@ -45,6 +45,6 @@ const plugin = require('../');
       t.same(res.body.query, testData.expected)
     })
 
-    t.tearDown(() => fastify.close())
+    t.teardown(() => fastify.close())
   })
 })


### PR DESCRIPTION
Fix the following warning in the tests:
```
(node:68746) [FSTDEP011] FastifyDeprecation: Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:68746) DeprecationWarning: tearDown() is deprecated, use teardown() instead
```

Highly appreciate it if you would add after accepting the `hacktoberfest-accepted` label to this PR